### PR TITLE
Add option FEEDLY_HOST for feedly.com provider

### DIFF
--- a/allauth/socialaccount/providers/feedly/views.py
+++ b/allauth/socialaccount/providers/feedly/views.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import requests
+from allauth.socialaccount import app_settings
 from allauth.socialaccount.providers.oauth2.views import (OAuth2Adapter,
                                                           OAuth2LoginView,
                                                           OAuth2CallbackView)
@@ -9,9 +10,9 @@ from .provider import FeedlyProvider
 
 class FeedlyOAuth2Adapter(OAuth2Adapter):
     provider_id = FeedlyProvider.id
-    access_token_url = 'https://cloud.feedly.com/v3/auth/token'
-    authorize_url = 'https://cloud.feedly.com/v3/auth/auth'
-    profile_url = 'https://cloud.feedly.com/v3/profile'
+    access_token_url = 'https://%s/v3/auth/token' % settings.get('FEEDLY_HOST', 'cloud.feedly.com')
+    authorize_url = 'https://%s/v3/auth/auth' % settings.get('FEEDLY_HOST', 'cloud.feedly.com')
+    profile_url = 'https://%s/v3/profile' % settings.get('FEEDLY_HOST', 'cloud.feedly.com')
 
     def complete_login(self, request, app, token, **kwargs):
         headers = {'Authorization': 'OAuth {0}'.format(token.token)}


### PR DESCRIPTION
API Feedly has two hosts:
- sandbox.feedly.com  (for development)
- cloud.feedly.com (for production)
